### PR TITLE
Added support for exponential notation in default parameters

### DIFF
--- a/docs/jsons.rst
+++ b/docs/jsons.rst
@@ -234,7 +234,7 @@ Single input item that allows insert single number.
       "parameterName": "beta",
       "label": "Beta",
       "placeholder": "0.1",
-      "defaultValue": 0.1,
+      "defaultValue": "0.1",
       "validations": {
             "type": "float",
             "min": "0.000001",
@@ -246,7 +246,7 @@ Single input item that allows insert single number.
 
 * **placeholder** (*string*) - value visible when field is empty
 
-* **defaultValue** (*float/int*) - field initial value
+* **defaultValue** (*string*) - field initial value
 
 * **validations** (*array*) - field validation rules
     

--- a/src/components/functions/forms/GenericForm.js
+++ b/src/components/functions/forms/GenericForm.js
@@ -11,8 +11,8 @@ const FormItem = Form.Item;
 const InputGroup = Input.Group;
 const Option = Select.Option;
 
-const floatPattern = /^\d+\.?\d*$/;
-const intPattern = /^\d+$/;
+const floatPattern = /^[+-]?\d+\.?\d*([eE][+-]?\d+)?$/;
+const intPattern = /^\d+([eE][+]?\d+)?$/;
 
 const inputFieldWidth = 170;
 const textLabelForInputSpan = 13;

--- a/src/components/functions/forms/GenericForm.js
+++ b/src/components/functions/forms/GenericForm.js
@@ -11,8 +11,12 @@ const FormItem = Form.Item;
 const InputGroup = Input.Group;
 const Option = Select.Option;
 
+// float in standard or exponential notation
+// e.g. -1.5e+2, 2, 10.2E-2, 1E4
 const floatPattern = /^[+-]?\d+\.?\d*([eE][+-]?\d+)?$/;
-const intPattern = /^\d+([eE][+]?\d+)?$/;
+// unsigned int in standard or exponential notation (negative exponent is not allowed)
+// e.g. 2, 1e3, 2e+4, 2E6
+const uintPattern = /^\d+([eE][+]?\d+)?$/;
 
 const inputFieldWidth = 170;
 const textLabelForInputSpan = 13;
@@ -149,7 +153,7 @@ class FormGenerator extends React.Component {
                         <Tooltip title={"Insert interval value or points number"} placement={"right"}>
                             {getFieldDecorator(pointNoName, {
                                 rules: [{
-                                    pattern: this.state.formData.intervalType === stepValue ? floatPattern : intPattern, message: "Incorrect value!"
+                                    pattern: this.state.formData.intervalType === stepValue ? floatPattern : uintPattern, message: "Incorrect value!"
                                 }, {
                                     required: true, message: "Please, insert a value!"
                                 }],
@@ -277,7 +281,7 @@ class FormGenerator extends React.Component {
         }
 
         if (value && validationRules) {
-            const pattern = validationRules.type && validationRules.type === "int" ? intPattern : floatPattern;
+            const pattern = validationRules.type && validationRules.type === "int" ? uintPattern : floatPattern;
             const regObj = RegExp(pattern);
             const fValue = parseFloat(value);
 
@@ -323,7 +327,7 @@ class FormGenerator extends React.Component {
         }
 
         if (value && validationRules) {
-            const pattern = validationRules.type && validationRules.type === "int" ? intPattern : floatPattern;
+            const pattern = validationRules.type && validationRules.type === "int" ? uintPattern : floatPattern;
             const regObj = RegExp(pattern);
             const fValue = parseFloat(value);
 

--- a/src/static/json/DataRange/CSDAEnergyAfterSlabMulti.json
+++ b/src/static/json/DataRange/CSDAEnergyAfterSlabMulti.json
@@ -26,7 +26,7 @@
             "parameterName": "slab_thickness_cm",
             "label": "Thickness [cm]",
             "placeholder": "Slab thickness [cm]",
-            "defaultValue": 2.0,
+            "defaultValue": "2.0",
             "description": "Thickness of a slab",
             "validations": {
                 "type": "float",

--- a/src/static/json/DataRange/CSDAEnergyAfterSlabSingle.json
+++ b/src/static/json/DataRange/CSDAEnergyAfterSlabSingle.json
@@ -11,7 +11,7 @@
       "parameterName": "E_initial_MeV_u",
       "label": "Initial Energy [MeV/amu]",
       "placeholder": "Initial energy",
-      "defaultValue": 150,
+      "defaultValue": "150",
       "validations": {
         "type": "float",
         "min": "0",
@@ -23,7 +23,7 @@
       "parameterName": "slab_thickness_cm",
       "label": "Slab thickness [cm]",
       "placeholder": "Slab thickness[cm]",
-      "defaultValue": 3.0,
+      "defaultValue": "3.0",
       "description": "Thickness of slab",
       "validations": {
         "type": "float",

--- a/src/static/json/DataRange/CSDARangeMulti.json
+++ b/src/static/json/DataRange/CSDARangeMulti.json
@@ -28,7 +28,7 @@
             "label": "Final Energy [MeV/amu]",
             "placeholder": "Final energy",
             "asManyAsPoints": true,
-            "defaultValue": 0,
+            "defaultValue": "0",
             "validations": {
                 "type": "float",
                 "min": "0",

--- a/src/static/json/DataRange/CSDARangeSingle.json
+++ b/src/static/json/DataRange/CSDARangeSingle.json
@@ -11,7 +11,7 @@
       "parameterName": "E_initial_MeV_u",
       "label": "Initial Energy [MeV/amu]",
       "placeholder": "Initial energy",
-      "defaultValue": 100,
+      "defaultValue": "100",
       "validations": {
         "type": "float",
         "min": "1e-7",
@@ -23,7 +23,7 @@
       "parameterName": "E_final_MeV_u",
       "label": "Final Energy [MeV/amu]",
       "placeholder": "Final energy",
-      "defaultValue": 0,
+      "defaultValue": "0",
       "validations": {
         "type": "float",
         "min": "0",

--- a/src/static/json/ElectronRange/MaxElectronRangeMSingle.json
+++ b/src/static/json/ElectronRange/MaxElectronRangeMSingle.json
@@ -11,7 +11,7 @@
       "parameterName": "E_MeV_u",
       "label": "Ion energy [MeV/amu]",
       "placeholder": "10",
-      "defaultValue": 10.0,
+      "defaultValue": "10.0",
       "validations": {
         "type": "float",
         "min": "0.000001",

--- a/src/static/json/PhysicsRoutines/BetaFromESingle.json
+++ b/src/static/json/PhysicsRoutines/BetaFromESingle.json
@@ -10,7 +10,7 @@
       "type": "input",
       "parameterName": "E_MeV_u",
       "label": "Energy \\(\\frac{\\mathrm{MeV}}{\\mathrm{amu}}\\)",
-      "defaultValue": 10,
+      "defaultValue": "10",
       "validations": {
         "type": "float",
         "min": "0.000001",

--- a/src/static/json/PhysicsRoutines/DoseFromFluence.json
+++ b/src/static/json/PhysicsRoutines/DoseFromFluence.json
@@ -35,7 +35,7 @@
       "parameterName": "fluence_cm2",
       "label": "Fluence [1/cm2]",
       "placeholder": "1e9",
-      "defaultValue": 1e9,
+      "defaultValue": "1e9",
       "asManyAsPoints": true,
       "description": "fluence in 1/cm2",
       "validations": {

--- a/src/static/json/PhysicsRoutines/DoseFromFluenceSingle.json
+++ b/src/static/json/PhysicsRoutines/DoseFromFluenceSingle.json
@@ -12,7 +12,7 @@
       "parameterName": "fluence_cm2",
       "label": "Fluence [1/cm2]",
       "placeholder": "1e9",
-      "defaultValue": 1e9,
+      "defaultValue": "1e9",
       "description": "fluence in 1/cm2",
       "validations": {
         "type": "float",
@@ -25,7 +25,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV/amu]",
       "placeholder": "150",
-      "defaultValue": 150,
+      "defaultValue": "150",
       "description": "Energy per unit mass",
       "validations": {
         "type": "float",

--- a/src/static/json/PhysicsRoutines/EFromBetaSingle.json
+++ b/src/static/json/PhysicsRoutines/EFromBetaSingle.json
@@ -11,7 +11,7 @@
       "parameterName": "beta",
       "label": "Beta",
       "placeholder": "0.1",
-      "defaultValue": 0.1,
+      "defaultValue": "0.1",
       "validations": {
         "type": "float",
         "min": "0.000001",

--- a/src/static/json/PhysicsRoutines/EFromGammaSingle.json
+++ b/src/static/json/PhysicsRoutines/EFromGammaSingle.json
@@ -11,7 +11,7 @@
       "parameterName": "gamma",
       "label": "γ",
       "placeholder": "Gamma",
-      "defaultValue": 2,
+      "defaultValue": "2",
       "validations": {
         "type": "float",
         "min": "1.00000001",

--- a/src/static/json/PhysicsRoutines/EFromMomentumSingle.json
+++ b/src/static/json/PhysicsRoutines/EFromMomentumSingle.json
@@ -11,7 +11,7 @@
       "parameterName": "momentum_MeV_c_u",
       "label": "Momentum[MeV/c/amu]",
       "placeholder": "momentum per particle",
-      "defaultValue": 300,
+      "defaultValue": "300",
       "validations": {
         "type": "float",
         "min": "0",

--- a/src/static/json/PhysicsRoutines/EffectiveChargeFromESingle.json
+++ b/src/static/json/PhysicsRoutines/EffectiveChargeFromESingle.json
@@ -10,7 +10,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV/amu]",
       "placeholder": "Energy [MeV/amu]",
-      "defaultValue": 10,
+      "defaultValue": "10",
       "validations": {
         "type": "float",
         "min": "0.000001",

--- a/src/static/json/PhysicsRoutines/EnergyLossDistributions.json
+++ b/src/static/json/PhysicsRoutines/EnergyLossDistributions.json
@@ -50,7 +50,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV]",
       "placeholder": "150.0",
-      "defaultValue": 150.0,
+      "defaultValue": "150.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -62,7 +62,7 @@
       "parameterName": "slab_thickness_mm",
       "label": "Slab thickness [mm]",
       "placeholder": "1.0",
-      "defaultValue": 1.0,
+      "defaultValue": "1.0",
       "validations": {
         "type": "float",
         "min": "0.000001",

--- a/src/static/json/PhysicsRoutines/GammaFromESingle.json
+++ b/src/static/json/PhysicsRoutines/GammaFromESingle.json
@@ -10,7 +10,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy",
       "placeholder": "10",
-      "defaultValue": 10,
+      "defaultValue": "10",
       "validations": {
         "type": "float",
         "min": "0",

--- a/src/static/json/PhysicsRoutines/RelMomentumFromESingle.json
+++ b/src/static/json/PhysicsRoutines/RelMomentumFromESingle.json
@@ -11,7 +11,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy",
       "placeholder": "Insert energy",
-      "defaultValue": 150,
+      "defaultValue": "150",
       "validations": {
         "type": "float",
         "min": "0.000001",

--- a/src/static/json/ProtonTherapyModels/BiologicalDoseModels.json
+++ b/src/static/json/ProtonTherapyModels/BiologicalDoseModels.json
@@ -26,7 +26,7 @@
       "parameterName": "entrance_dose_Gy",
       "label": "Entrance dose [Gy]",
       "placeholder": "2.0",
-      "defaultValue": 2.0,
+      "defaultValue": "2.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -38,7 +38,7 @@
       "parameterName": "ref_alpha_beta_ratio",
       "label": "reference α/β",
       "placeholder": "2.0",
-      "defaultValue": 2.0,
+      "defaultValue": "2.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -50,7 +50,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV]",
       "placeholder": "150.0",
-      "defaultValue": 150.0,
+      "defaultValue": "150.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -62,7 +62,7 @@
       "parameterName": "sigma_E_MeV_u",
       "label": "Energy spread (σ) [MeV]",
       "placeholder": "1.5",
-      "defaultValue": 1.5,
+      "defaultValue": "1.5",
       "validations": {
         "type": "float",
         "min": "0.0",

--- a/src/static/json/ProtonTherapyModels/BortfeldModelDepthDose.json
+++ b/src/static/json/ProtonTherapyModels/BortfeldModelDepthDose.json
@@ -26,7 +26,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV]",
       "placeholder": "150.0",
-      "defaultValue": 150.0,
+      "defaultValue": "150.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -38,7 +38,7 @@
       "parameterName": "sigma_E_MeV_u",
       "label": "Energy spread (σ) [MeV]",
       "placeholder": "1.5",
-      "defaultValue": 1.5,
+      "defaultValue": "1.5",
       "validations": {
         "type": "float",
         "min": "0.0",
@@ -50,7 +50,7 @@
       "parameterName": "entrance_dose_Gy",
       "label": "Entrance dose [Gy]",
       "placeholder": "2.0",
-      "defaultValue": 2,
+      "defaultValue": "2",
       "description": "dose in Gy",
       "validations": {
         "type": "float",

--- a/src/static/json/ProtonTherapyModels/ProtonRBEModels.json
+++ b/src/static/json/ProtonTherapyModels/ProtonRBEModels.json
@@ -26,7 +26,7 @@
       "parameterName": "entrance_dose_Gy",
       "label": "Entrance dose [Gy]",
       "placeholder": "2.0",
-      "defaultValue": 2.0,
+      "defaultValue": "2.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -38,7 +38,7 @@
       "parameterName": "ref_alpha_beta_ratio",
       "label": "reference α/β",
       "placeholder": "2.0",
-      "defaultValue": 2.0,
+      "defaultValue": "2.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -50,7 +50,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV]",
       "placeholder": "150.0",
-      "defaultValue": 150.0,
+      "defaultValue": "150.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -62,7 +62,7 @@
       "parameterName": "sigma_E_MeV_u",
       "label": "Energy spread (σ) [MeV]",
       "placeholder": "1.5",
-      "defaultValue": 1.5,
+      "defaultValue": "1.5",
       "validations": {
         "type": "float",
         "min": "0.0",

--- a/src/static/json/ProtonTherapyModels/WilkensModelDepthLET.json
+++ b/src/static/json/ProtonTherapyModels/WilkensModelDepthLET.json
@@ -26,7 +26,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV]",
       "placeholder": "150.0",
-      "defaultValue": 150.0,
+      "defaultValue": "150.0",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -38,7 +38,7 @@
       "parameterName": "sigma_E_MeV_u",
       "label": "Energy spread (σ) [MeV]",
       "placeholder": "1.5",
-      "defaultValue": 1.5,
+      "defaultValue": "1.5",
       "validations": {
         "type": "float",
         "min": "0.0",

--- a/src/static/json/RDD/RDD.json
+++ b/src/static/json/RDD/RDD.json
@@ -27,7 +27,7 @@
       "parameterName": "E_MeV_u",
       "label": "Energy [MeV/amu]",
       "placeholder": "150",
-      "defaultValue": 150,
+      "defaultValue": "150",
       "validations": {
         "type": "float",
         "min": "0.000001",
@@ -65,7 +65,7 @@
       "parameterName": "rdd_parameter",
       "label": "Model params:",
       "asManyAsPoints": false,
-      "defaultValue": 0.00000001,
+      "defaultValue": "0.00000001",
       "description": "Model parameter"
     },
     {


### PR DESCRIPTION
Fixes #301

Default values of inputs were stored as numbers in static json files, therefore exponential notation was evaluated to standard number. Changing default values to strings fixes the problem.
![image](https://user-images.githubusercontent.com/32063111/56156523-bc0df600-5fbd-11e9-9057-f638891d7c3d.png)